### PR TITLE
Added the /node/dataset/active URL to allow for HomeAssistant adoption. (TZ-366)

### DIFF
--- a/components/esp_ot_br_server/private_include/esp_br_web_api.h
+++ b/components/esp_ot_br_server/private_include/esp_br_web_api.h
@@ -30,6 +30,7 @@ extern "C" {
 #define ESP_OT_REST_API_NODE_EXTPANID_PATH "/node/ext-panid"
 #define ESP_OT_REST_API_NODE_BORDERAGENTID_PATH "/node/ba-id"
 #define ESP_OT_REST_API_NODE_ACTIVE_DATASET_TLVS_PATH "/node/active-dataset-tlvs"
+#define ESP_OT_REST_API_NODE_DATASET_ACTIVE_PATH "/node/dataset/active"
 #define ESP_OT_REST_API_PROPERTIES_PATH "/get_properties"
 #define ESP_OT_REST_API_AVAILABLE_NETWORK_PATH "/available_network"
 #define ESP_OT_REST_API_NODE_INFORMATION_PATH "/node_information"
@@ -141,6 +142,13 @@ cJSON *handle_ot_resource_node_baid_request(void);
  * @return The cJSON object of Thread active dataset tlv
  */
 cJSON *handle_ot_resource_node_active_dataset_tlv_request(void);
+
+/**
+ * @brief Provide an entry ot get active dataset tlv of Thread
+ *
+ * @return The char array object of Thread active dataset tlv
+ */
+char *handle_ot_resource_node_active_dataset_tlv_request_plain_text(void);
 
 /**
  * @brief Handle the Thread network formation @param request and provide @param log

--- a/components/esp_ot_br_server/src/esp_br_web_api.c
+++ b/components/esp_ot_br_server/src/esp_br_web_api.c
@@ -186,6 +186,26 @@ cJSON *handle_ot_resource_node_active_dataset_tlv_request()
     return cJSON_CreateString(format);
 }
 
+char *handle_ot_resource_node_active_dataset_tlv_request_plain_text()
+{
+    char format[256];
+    otOperationalDatasetTlvs dataset;
+    esp_openthread_lock_acquire(portMAX_DELAY);
+    ESP_RETURN_ON_FALSE(!otDatasetGetActiveTlvs(esp_openthread_get_instance(), &dataset), NULL, API_TAG,
+                        "Failed to get thread dataset tlv");
+    esp_openthread_lock_release();
+    ESP_RETURN_ON_FALSE(sizeof(format) >= (dataset.mLength * 2), NULL, API_TAG, "Invalid Size");
+    ESP_RETURN_ON_FALSE(!hex_to_string(dataset.mTlvs, format, dataset.mLength), NULL, API_TAG,
+                        "Failed to convert thread dataset tlv");
+    char *str = malloc(256 * sizeof(char));
+    if(str == NULL) return NULL;
+    for (size_t i = 0; i < 256; i++)
+    {
+        str[i] = format[i];
+    }
+    
+    return str;
+}
 /*----------------------------------------------------------------------
                                 thread status
 ----------------------------------------------------------------------*/

--- a/docs/en/codelab/web-gui.rst
+++ b/docs/en/codelab/web-gui.rst
@@ -45,7 +45,7 @@ Thread REST APIs
 
 The ESP Thread Border Router server provides the REST APIs that are compatible with `ot-br-posix <https://github.com/openthread/ot-br-posix>`_
 
-The Thread REST APIs field include ``/diagnostics``, ``/node``, ``/node/rloc``, ``/node/rloc16``, ``/node/ext-address``, ``/node/state``, ``/node/network-name``, ``/node/leader-data``, ``/node/num-of-router``, ``/node/ext-panid``, ``/node/ba-id`` and ``/node/active-dataset-tlvs``.
+The Thread REST APIs field include ``/diagnostics``, ``/node``, ``/node/rloc``, ``/node/rloc16``, ``/node/ext-address``, ``/node/state``, ``/node/network-name``, ``/node/leader-data``, ``/node/num-of-router``, ``/node/ext-panid``, ``/node/ba-id``, ``/node/active-dataset-tlvs`` and ``/node/dataset/active``.
 
 Entering this link to the browser of Linux machine:
 


### PR DESCRIPTION
Fix for issue [Update REST API to latest OT-BR-POSIX (TZ-217)](vhttps://github.com/espressif/esp-thread-br/issues/27).

This resolves the issue with adding the otbr to home assistant.