### PR TITLE
Make SPI pins configurable via menuconfig (TZ-369)

### DIFF
--- a/examples/basic_thread_border_router/main/esp_ot_config.h
+++ b/examples/basic_thread_border_router/main/esp_ot_config.h
@@ -43,29 +43,29 @@
         },                                                 \
     }
 #else
-#define ESP_OPENTHREAD_DEFAULT_RADIO_CONFIG()      \
-    {                                              \
-        .radio_mode = RADIO_MODE_SPI_RCP,          \
-        .radio_spi_config = {                      \
-            .host_device = SPI2_HOST,              \
-            .dma_channel = 2,                      \
-            .spi_interface =                       \
-                {                                  \
-                    .mosi_io_num = 11,             \
-                    .miso_io_num = 13,             \
-                    .sclk_io_num = 12,             \
-                },                                 \
-            .spi_device =                          \
-                {                                  \
-                    .cs_ena_pretrans = 2,          \
-                    .input_delay_ns = 100,         \
-                    .mode = 0,                     \
-                    .clock_speed_hz = 2500 * 1000, \
-                    .spics_io_num = 10,            \
-                    .queue_size = 5,               \
-                },                                 \
-            .intr_pin = CONFIG_PIN_TO_RCP_BOOT,    \
-        },                                         \
+#define ESP_OPENTHREAD_DEFAULT_RADIO_CONFIG()              \
+    {                                                      \
+        .radio_mode = RADIO_MODE_SPI_RCP,                  \
+        .radio_spi_config = {                              \
+            .host_device = SPI2_HOST,                      \
+            .dma_channel = 2,                              \
+            .spi_interface =                               \
+                {                                          \
+                    .mosi_io_num = CONFIG_PIN_TO_RCP_MOSI, \
+                    .miso_io_num = CONFIG_PIN_TO_RCP_MISO, \
+                    .sclk_io_num = CONFIG_PIN_TO_RCP_SCLK, \
+                },                                         \
+            .spi_device =                                  \
+                {                                          \
+                    .cs_ena_pretrans = 2,                  \
+                    .input_delay_ns = 100,                 \
+                    .mode = 0,                             \
+                    .clock_speed_hz = 2500 * 1000,         \
+                    .spics_io_num = CONFIG_PIN_TO_RCP_CS,  \
+                    .queue_size = 5,                       \
+                },                                         \
+            .intr_pin = CONFIG_PIN_TO_RCP_BOOT,            \
+        },                                                 \
     }
 #endif // CONFIG_OPENTHREAD_RADIO_SPINEL_UART OR  CONFIG_OPENTHREAD_RADIO_SPINEL_SPI
 

--- a/examples/common/thread_border_router/Kconfig.projbuild
+++ b/examples/common/thread_border_router/Kconfig.projbuild
@@ -33,6 +33,26 @@ menu "ESP Thread Border Router Example"
         config PIN_TO_RCP_RX
             int "Pin to RCP RX"
             default "18"
+
+        config PIN_TO_RCP_CS
+            depends on OPENTHREAD_RADIO_SPINEL_SPI
+            int "Pin to RCP SPI CS"
+            default "10"
+
+        config PIN_TO_RCP_SCLK
+            depends on OPENTHREAD_RADIO_SPINEL_SPI
+            int "Pin to RCP SPI SCLK"
+            default "12"
+
+        config PIN_TO_RCP_MISO
+            depends on OPENTHREAD_RADIO_SPINEL_SPI
+            int "Pin to RCP SPI MISO"
+            default "13"
+
+        config PIN_TO_RCP_MOSI
+            depends on OPENTHREAD_RADIO_SPINEL_SPI
+            int "Pin to RCP SPI MISO"
+            default "11"
     endmenu
 
     config OPENTHREAD_BR_AUTO_UPDATE_RCP

--- a/examples/common/thread_border_router/Kconfig.projbuild
+++ b/examples/common/thread_border_router/Kconfig.projbuild
@@ -51,7 +51,7 @@ menu "ESP Thread Border Router Example"
 
         config PIN_TO_RCP_MOSI
             depends on OPENTHREAD_RADIO_SPINEL_SPI
-            int "Pin to RCP SPI MISO"
+            int "Pin to RCP SPI MOSI"
             default "11"
     endmenu
 


### PR DESCRIPTION
This PR allows configuration of the SPI GPIO pins when SPI is used for communication between the host and RCP.