### PR TITLE
Fix compilation issue when dynamic logging is disabled in border_router_launch.c (TZ-439)

### DIFF
--- a/examples/common/thread_border_router/src/border_router_launch.c
+++ b/examples/common/thread_border_router/src/border_router_launch.c
@@ -102,8 +102,11 @@ static void ot_task_worker(void *ctx)
     try_update_ot_rcp(&s_openthread_platform_config);
 #endif
     ESP_ERROR_CHECK(esp_netif_attach(openthread_netif, esp_openthread_netif_glue_init(&s_openthread_platform_config)));
-
+    
+#if CONFIG_OPENTHREAD_LOG_LEVEL_DYNAMIC
     (void)otLoggingSetLevel(CONFIG_LOG_DEFAULT_LEVEL);
+#endif
+
     esp_openthread_cli_init();
     ESP_ERROR_CHECK(esp_netif_set_default_netif(openthread_netif));
     esp_cli_custom_command_init();

--- a/examples/common/thread_border_router/src/border_router_launch.c
+++ b/examples/common/thread_border_router/src/border_router_launch.c
@@ -102,7 +102,7 @@ static void ot_task_worker(void *ctx)
     try_update_ot_rcp(&s_openthread_platform_config);
 #endif
     ESP_ERROR_CHECK(esp_netif_attach(openthread_netif, esp_openthread_netif_glue_init(&s_openthread_platform_config)));
-    
+
 #if CONFIG_OPENTHREAD_LOG_LEVEL_DYNAMIC
     (void)otLoggingSetLevel(CONFIG_LOG_DEFAULT_LEVEL);
 #endif


### PR DESCRIPTION
When dynamic logging is disabled, the code did not compile due to the `otLoggingSetLevel` function from `openthread/logging.h` being unavailable. This function is now surrounded by `CONFIG_OPENTHREAD_LOG_LEVEL_DYNAMIC`, resolving the issue.