### PR TITLE
fix(config): fix default SPI config to disable QSPI gpio (TZ-456)

### DIFF
--- a/examples/basic_thread_border_router/main/esp_ot_config.h
+++ b/examples/basic_thread_border_router/main/esp_ot_config.h
@@ -54,6 +54,8 @@
                     .mosi_io_num = CONFIG_PIN_TO_RCP_MOSI, \
                     .miso_io_num = CONFIG_PIN_TO_RCP_MISO, \
                     .sclk_io_num = CONFIG_PIN_TO_RCP_SCLK, \
+                    .quadwp_io_num = -1,                   \
+                    .quadhd_io_num = -1,                   \
                 },                                         \
             .spi_device =                                  \
                 {                                          \


### PR DESCRIPTION
Currently if RCP is used in SPI mode, the GPIO0 is always configured as an output. See https://github.com/espressif/esp-thread-br/issues/44.
This PR ensure SPI bus is not configured in QSPI mode (and especially avoid the SPI driver to configure GPIO0 as QSPI HD and WP pins)