### PR TITLE
feat(rcp): add option to select esp32c6 as rcp chip (TZ-1583)

### DIFF
--- a/components/esp_rcp_update/idf_component.yml
+++ b/components/esp_rcp_update/idf_component.yml
@@ -1,9 +1,9 @@
-version: "1.3.1"
+version: "1.3.2"
 description: Espressif RCP Update Component for Thread Border Router and Zigbee Gateway
 url: https://github.com/espressif/esp-thread-br/tree/main/components/esp_rcp_update
 dependencies:
   espressif/esp-serial-flasher:
-    version: "~0.0.0"
+    version: "1.8.0"
 
   idf:
     version: ">=5.0"

--- a/components/esp_rcp_update/include/esp_rcp_update.h
+++ b/components/esp_rcp_update/include/esp_rcp_update.h
@@ -20,6 +20,8 @@ extern "C" {
 typedef enum {
     RCP_TYPE_INVALID = 0,  /* Invalid type */
     RCP_TYPE_ESP32H2_UART, /* ESP32H2 connected via UART */
+    RCP_TYPE_ESP32C6_UART, /* ESP32C6 connected via UART */
+    RCP_TYPE_MAX,          /* Max type */
 } esp_rcp_type_t;
 
 /**

--- a/components/esp_rcp_update/src/esp_rcp_update.c
+++ b/components/esp_rcp_update/src/esp_rcp_update.c
@@ -207,8 +207,8 @@ esp_err_t esp_rcp_submit_new_image()
 esp_err_t esp_rcp_update_init(const esp_rcp_update_config_t *update_config)
 {
     ESP_RETURN_ON_ERROR(nvs_open("storage", NVS_READWRITE, &s_handle.nvs_handle), "TAG", "Failed to open nvs");
-    ESP_RETURN_ON_FALSE(update_config->rcp_type == RCP_TYPE_ESP32H2_UART, ESP_ERR_INVALID_ARG, TAG,
-                        "Unsupported RCP type");
+    ESP_RETURN_ON_FALSE(update_config->rcp_type > RCP_TYPE_INVALID && update_config->rcp_type < RCP_TYPE_MAX,
+                        ESP_ERR_INVALID_ARG, TAG, "Unsupported RCP type");
 
     s_handle.update_config = *update_config;
     load_rcp_update_seq(&s_handle);


### PR DESCRIPTION
## Description

This PR adds an option to configure ESP32-C6 as an alternative RCP. Previously, only ESP32-H2 was supported as an RCP option.
For more information, please take a look at #129.

## Changes
- Added ESP32-C6 UART type to RCP types in `esp_rcp_update.h`
- Updated `esp_rcp_update.c` to accept ESP32-C6 as a valid RCP type
- Added configuration options in Kconfig to select between ESP32-H2 and ESP32-C6
- Updated docs with config options for ESP32-C6 as RCP
- Bumped version of `esp-serial-flasher` in `esp_rcp_update` component for ESP32-C6 support; therefore also bumped version of `esp_rcp_update` component

## Additional notes

- I don't know the whole code base or other related projects, so I'm not sure if the changes could introduce any side effects. Especially regarding other projects that may use the `esp_rcp_update` component.
- I'm not sure how versioning and release for `esp_rcp_update` component works, so I just increased the version number on patch level
- Further adjustments are therefore very welcome to make the code mergeable

## Related

Resolves #129

## Testing

- Tested in a clean environment (esp-idf container v5.4)
- Tested with standalone module config and an ESP32-C6 board as RCP
- not tested with an ESP32-H2 board as RCP because I don't have one currently

### How to Test

1. For testing with the changed `esp_rcp_update` component, I put following lines in `idf_component.yml` for `basic_thread_border_router` to use the local code base:
  ```
     espressif/esp_rcp_update:
     path: ../../../components/esp_rcp_update
  ```

2. Build the RCP firmware targeting ESP32-C6:
  ```
    cd $IDF_PATH/examples/openthread/ot_rcp
    idf.py set-target esp32c6
    idf.py build
  ```

3. Configure the border router project to use ESP32-C6 as RCP:
  ```
   cd esp-thread-br/examples/basic_thread_border_router
   idf.py menuconfig
  ```
   Set `ESP Thread Border Router Example → Border router board type` to `Standalone dev kits` first and then `ESP Thread Border Router Example → RCP target chip` to `ESP32-C6`.

4. Build and flash the border router:
  ```
    cd esp-thread-br/examples/basic_thread_border_router
    idf.py -p ${PORT_TO_BR} flash monitor
  ```
