### PR TITLE
Fix network getting network properties when network name is 16 characters (TZ-1891)

### DIFF
--- a/components/esp_ot_br_server/src/esp_br_web_api.c
+++ b/components/esp_ot_br_server/src/esp_br_web_api.c
@@ -358,7 +358,7 @@ static esp_err_t get_openthread_network_properties(otInstance *ins, thread_netwo
     ESP_RETURN_ON_FALSE(ins && network, ESP_FAIL, API_TAG, "Invalid instance or openthread network");
     char output[64] = "";
     sprintf(output, "%s", otThreadGetNetworkName(ins));
-    ESP_RETURN_ON_FALSE((strlen(output) + 1) < sizeof(otNetworkName), ESP_FAIL, API_TAG, "Network name is too long");
+    ESP_RETURN_ON_FALSE(strlen(output) < sizeof(otNetworkName), ESP_FAIL, API_TAG, "Network name is too long");
 
     memcpy(&network->name, output, strlen(output) + 1);                               /* 1. name */
     network->panid = otLinkGetPanId(ins);                                             /* 2. PANID */


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->
Per @gytxxsy in issue #141, changed https://github.com/espressif/esp-thread-br/blob/main/components/esp_ot_br_server/src/esp_br_web_api.c#L361 from 
```
ESP_RETURN_ON_FALSE((strlen(output) + 1) < sizeof(otNetworkName), ESP_FAIL, API_TAG, "Network name is too long");
```
to
```
ESP_RETURN_ON_FALSE(strlen(output) < sizeof(otNetworkName), ESP_FAIL, API_TAG, "Network name is too long");
```

This ensures the network status view loads properly when the network name is 16 characters, such as when it is created by an Apple HomePod Mini.
<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

Fixes #141 

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

I modified this code line in a cloned repo in WSL and pushed it to 2 OTBRs then booted them then used the web UI to see if network status was now loading, whilst also watching logs on the OTBR.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
