### PR TITLE
Support native radio mode

### DIFF
--- a/examples/basic_thread_border_router/main/esp_ot_br.c
+++ b/examples/basic_thread_border_router/main/esp_ot_br.c
@@ -68,6 +68,10 @@ void app_main(void)
     // * TREL reception (The Thread Radio Encapsulation Link needs an eventfd for reception.)
     max_eventfd++;
 #endif
+#if CONFIG_OPENTHREAD_BORDER_ROUTER
+    // * discovery delegate (The discovery delegate needs an eventfd for border router)
+    max_eventfd++;
+#endif
     esp_vfs_eventfd_config_t eventfd_config = {
         .max_fds = max_eventfd,
     };

--- a/examples/basic_thread_border_router/main/esp_ot_config.h
+++ b/examples/basic_thread_border_router/main/esp_ot_config.h
@@ -38,6 +38,11 @@
             .tx_pin = CONFIG_PIN_TO_RCP_RX,                \
         },                                                 \
     }
+#elif CONFIG_OPENTHREAD_RADIO_NATIVE
+#define ESP_OPENTHREAD_DEFAULT_RADIO_CONFIG()              \
+    {                                                      \
+        .radio_mode = RADIO_MODE_NATIVE,                   \
+    }
 #else
 #define ESP_OPENTHREAD_DEFAULT_RADIO_CONFIG()              \
     {                                                      \
@@ -65,7 +70,7 @@
             .intr_pin = CONFIG_PIN_TO_RCP_BOOT,            \
         },                                                 \
     }
-#endif // CONFIG_OPENTHREAD_RADIO_SPINEL_UART OR  CONFIG_OPENTHREAD_RADIO_SPINEL_SPI
+#endif // CONFIG_OPENTHREAD_RADIO_SPINEL_UART OR CONFIG_OPENTHREAD_RADIO_NATIVE OR CONFIG_OPENTHREAD_RADIO_SPINEL_SPI
 
 #if CONFIG_AUTO_UPDATE_RCP
 


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description
Allows to run the example on a single SoC, handling both Wifi and Thread, with no RCP necessary. 
Fixes build errors of undeclared SPI pins (unnecessary in this config) and discovery delegate eventfd.

These are the minimal changes to make it compile/work. I did not change sdkconfig.defaults, so to activate this mode `CONFIG_ESP_COEX_SW_COEXIST_ENABLE` + `CONFIG_OPENTHREAD_RADIO_NATIVE` should be set as usual via menuconfig etc. `CONFIG_AUTO_UPDATE_RCP` should be unset as there is obviously nothing to update.
<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related
The ot-br example in IDF is setup like this by default on the ESP32-C6 target: 
https://github.com/espressif/esp-idf/tree/master/examples/openthread/ot_br#configure-the-project
<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing
I did deploy it in on a single ESP32-C6 for my thread network at home for a few weeks and it works reliably.
<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
