### PR TITLE
Fixes reboots after getting valid IP, returning to AP mode by mistake

### DIFF
--- a/examples/m5stack_thread_border_router/sdkconfig.defaults
+++ b/examples/m5stack_thread_border_router/sdkconfig.defaults
@@ -124,7 +124,7 @@ CONFIG_LV_MEM_CUSTOM=y
 #
 # Example Connection Configuration
 #
-CONFIG_EXAMPLE_WIFI_CONN_MAX_RETRY=-1
+CONFIG_EXAMPLE_WIFI_CONN_MAX_RETRY=6
 
 #
 # http server


### PR DESCRIPTION
## Description

This patch allows the M5stack TBR to obtain valid credentials.  After obtaininb valid IP address, the TBR reboots and re-enters in AP mode, refusing the credentials.

Note: changing CONFIG_EXAMPLE_WIFI_CONN_MAX_RETRY=6 solves the issue, but you may want to look at the code which is consuming CONFIG_EXAMPLE_WIFI_CONN_MAX_RETRY, because maybe your intention was to have infinite retries.

## Checklist

Before submitting a Pull Request, please ensure the following:

- [X ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
