### PR TITLE
Refactor boolean assignments from cJSON

### DIFF
--- a/components/esp_ot_br_server/src/esp_br_web_base.c
+++ b/components/esp_ot_br_server/src/esp_br_web_base.c
@@ -325,7 +325,7 @@ esp_err_t network_formation_param_json_convert2_struct(const cJSON *root, cJSON 
 
     temp = cJSON_GetObjectItem(root, "defaultRoute");
     if (temp && temp->type != cJSON_NULL)
-        param->default_route = temp->valueint;
+        param->default_route = (bool)cJSON_GetNumberValue(temp);
     else
         param->default_route = false;
 
@@ -883,7 +883,7 @@ esp_err_t Json2Timestamp(const cJSON *jsonTimestamp, otTimestamp *aTimestamp)
 
     value = cJSON_GetObjectItemCaseSensitive(jsonTimestamp, "Authoritative");
     if (cJSON_IsBool(value)) {
-        aTimestamp->mAuthoritative = value->valueint;
+        aTimestamp->mAuthoritative = cJSON_IsTrue(value);
     }
 
     return ESP_OK;
@@ -900,47 +900,47 @@ esp_err_t Json2SecurityPolicy(const cJSON *jsonSecurityPolicy, otSecurityPolicy 
 
     value = cJSON_GetObjectItemCaseSensitive(jsonSecurityPolicy, "ObtainNetworkKey");
     if (cJSON_IsBool(value)) {
-        aSecurityPolicy->mObtainNetworkKeyEnabled = value->valueint;
+        aSecurityPolicy->mObtainNetworkKeyEnabled = cJSON_IsTrue(value);
     }
 
     value = cJSON_GetObjectItemCaseSensitive(jsonSecurityPolicy, "NativeCommissioning");
     if (cJSON_IsBool(value)) {
-        aSecurityPolicy->mNativeCommissioningEnabled = value->valueint;
+        aSecurityPolicy->mNativeCommissioningEnabled = cJSON_IsTrue(value);
     }
 
     value = cJSON_GetObjectItemCaseSensitive(jsonSecurityPolicy, "Routers");
     if (cJSON_IsBool(value)) {
-        aSecurityPolicy->mRoutersEnabled = value->valueint;
+        aSecurityPolicy->mRoutersEnabled = cJSON_IsTrue(value);
     }
 
     value = cJSON_GetObjectItemCaseSensitive(jsonSecurityPolicy, "ExternalCommissioning");
     if (cJSON_IsBool(value)) {
-        aSecurityPolicy->mExternalCommissioningEnabled = value->valueint;
+        aSecurityPolicy->mExternalCommissioningEnabled = cJSON_IsTrue(value);
     }
 
     value = cJSON_GetObjectItemCaseSensitive(jsonSecurityPolicy, "CommercialCommissioning");
     if (cJSON_IsBool(value)) {
-        aSecurityPolicy->mCommercialCommissioningEnabled = value->valueint;
+        aSecurityPolicy->mCommercialCommissioningEnabled = cJSON_IsTrue(value);
     }
 
     value = cJSON_GetObjectItemCaseSensitive(jsonSecurityPolicy, "AutonomousEnrollment");
     if (cJSON_IsBool(value)) {
-        aSecurityPolicy->mAutonomousEnrollmentEnabled = value->valueint;
+        aSecurityPolicy->mAutonomousEnrollmentEnabled = cJSON_IsTrue(value);
     }
 
     value = cJSON_GetObjectItemCaseSensitive(jsonSecurityPolicy, "NetworkKeyProvisioning");
     if (cJSON_IsBool(value)) {
-        aSecurityPolicy->mNetworkKeyProvisioningEnabled = value->valueint;
+        aSecurityPolicy->mNetworkKeyProvisioningEnabled = cJSON_IsTrue(value);
     }
 
     value = cJSON_GetObjectItemCaseSensitive(jsonSecurityPolicy, "TobleLink");
     if (cJSON_IsBool(value)) {
-        aSecurityPolicy->mTobleLinkEnabled = value->valueint;
+        aSecurityPolicy->mTobleLinkEnabled = cJSON_IsTrue(value);
     }
 
     value = cJSON_GetObjectItemCaseSensitive(jsonSecurityPolicy, "NonCcmRouters");
     if (cJSON_IsBool(value)) {
-        aSecurityPolicy->mNonCcmRoutersEnabled = value->valueint;
+        aSecurityPolicy->mNonCcmRoutersEnabled = cJSON_IsTrue(value);
     }
 
     return ESP_OK;

--- a/components/esp_ot_br_server/src/esp_br_web_base.c
+++ b/components/esp_ot_br_server/src/esp_br_web_base.c
@@ -325,7 +325,7 @@ esp_err_t network_formation_param_json_convert2_struct(const cJSON *root, cJSON 
 
     temp = cJSON_GetObjectItem(root, "defaultRoute");
     if (temp && temp->type != cJSON_NULL)
-        param->default_route = (bool)cJSON_GetNumberValue(temp);
+        param->default_route = temp->valueint;
     else
         param->default_route = false;
 
@@ -883,7 +883,7 @@ esp_err_t Json2Timestamp(const cJSON *jsonTimestamp, otTimestamp *aTimestamp)
 
     value = cJSON_GetObjectItemCaseSensitive(jsonTimestamp, "Authoritative");
     if (cJSON_IsBool(value)) {
-        aTimestamp->mAuthoritative = (bool)cJSON_GetNumberValue(value);
+        aTimestamp->mAuthoritative = value->valueint;
     }
 
     return ESP_OK;
@@ -900,47 +900,47 @@ esp_err_t Json2SecurityPolicy(const cJSON *jsonSecurityPolicy, otSecurityPolicy 
 
     value = cJSON_GetObjectItemCaseSensitive(jsonSecurityPolicy, "ObtainNetworkKey");
     if (cJSON_IsBool(value)) {
-        aSecurityPolicy->mObtainNetworkKeyEnabled = (bool)cJSON_GetNumberValue(value);
+        aSecurityPolicy->mObtainNetworkKeyEnabled = value->valueint;
     }
 
     value = cJSON_GetObjectItemCaseSensitive(jsonSecurityPolicy, "NativeCommissioning");
     if (cJSON_IsBool(value)) {
-        aSecurityPolicy->mNativeCommissioningEnabled = (bool)cJSON_GetNumberValue(value);
+        aSecurityPolicy->mNativeCommissioningEnabled = value->valueint;
     }
 
     value = cJSON_GetObjectItemCaseSensitive(jsonSecurityPolicy, "Routers");
     if (cJSON_IsBool(value)) {
-        aSecurityPolicy->mRoutersEnabled = (bool)cJSON_GetNumberValue(value);
+        aSecurityPolicy->mRoutersEnabled = value->valueint;
     }
 
     value = cJSON_GetObjectItemCaseSensitive(jsonSecurityPolicy, "ExternalCommissioning");
     if (cJSON_IsBool(value)) {
-        aSecurityPolicy->mExternalCommissioningEnabled = (bool)cJSON_GetNumberValue(value);
+        aSecurityPolicy->mExternalCommissioningEnabled = value->valueint;
     }
 
     value = cJSON_GetObjectItemCaseSensitive(jsonSecurityPolicy, "CommercialCommissioning");
     if (cJSON_IsBool(value)) {
-        aSecurityPolicy->mCommercialCommissioningEnabled = (bool)cJSON_GetNumberValue(value);
+        aSecurityPolicy->mCommercialCommissioningEnabled = value->valueint;
     }
 
     value = cJSON_GetObjectItemCaseSensitive(jsonSecurityPolicy, "AutonomousEnrollment");
     if (cJSON_IsBool(value)) {
-        aSecurityPolicy->mAutonomousEnrollmentEnabled = (bool)cJSON_GetNumberValue(value);
+        aSecurityPolicy->mAutonomousEnrollmentEnabled = value->valueint;
     }
 
     value = cJSON_GetObjectItemCaseSensitive(jsonSecurityPolicy, "NetworkKeyProvisioning");
     if (cJSON_IsBool(value)) {
-        aSecurityPolicy->mNetworkKeyProvisioningEnabled = (bool)cJSON_GetNumberValue(value);
+        aSecurityPolicy->mNetworkKeyProvisioningEnabled = value->valueint;
     }
 
     value = cJSON_GetObjectItemCaseSensitive(jsonSecurityPolicy, "TobleLink");
     if (cJSON_IsBool(value)) {
-        aSecurityPolicy->mTobleLinkEnabled = (bool)cJSON_GetNumberValue(value);
+        aSecurityPolicy->mTobleLinkEnabled = value->valueint;
     }
 
     value = cJSON_GetObjectItemCaseSensitive(jsonSecurityPolicy, "NonCcmRouters");
     if (cJSON_IsBool(value)) {
-        aSecurityPolicy->mNonCcmRoutersEnabled = (bool)cJSON_GetNumberValue(value);
+        aSecurityPolicy->mNonCcmRoutersEnabled = value->valueint;
     }
 
     return ESP_OK;


### PR DESCRIPTION
## Description

SecurityPolicy flags in the active Thread dataset cannot be set to
false. They are always forced to true, regardless of the input.

Steps to reproduce:
1. Set an active dataset with all five optional SecurityPolicy flags
(CommercialCommissioning, AutonomousEnrollment, NetworkKeyProvisioning,
TobleLink, NonCcmRouters) explicitly set to false via PUT /node/dataset/active with a JSON body containing
"false" for all five fields.
2. Wait for the changes to take effect.
3. Read back the dataset GET /node/dataset/active

The actual bool value is mapped to item->valueint (1 for true, 0 for false).

## Related

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
