### PR TITLE
feat(br_server): add REST API for Border Agent ephemeral key (ePSKc)

### DIFF
--- a/components/esp_ot_br_server/include/esp_br_web.h
+++ b/components/esp_ot_br_server/include/esp_br_web.h
@@ -6,6 +6,9 @@
 
 #pragma once
 
+#include <stdbool.h>
+#include <stddef.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -16,6 +19,31 @@ extern "C" {
  * @param[in] base_path is the virtual file path of web server
  */
 void esp_br_web_start(char *base_path);
+
+/** Size of an ePSKc TAP string buffer: 8 digits + checksum digit + '\0' */
+#define ESP_BR_EPSKC_TAP_LEN 10
+
+/**
+ * @brief Record (or clear) the currently active ePSKc TAP, so that any UI which
+ * did not itself activate the ephemeral key (e.g. the M5Stack on-screen UI when
+ * the REST API started the session, or vice versa) can still discover and
+ * display it. Backed by an atomic, independently thread-safe of the OpenThread
+ * lock, so it is safe to call regardless of whether that lock is held.
+ *
+ * @param[in] tap The active TAP string, or NULL/empty to clear it (session stopped).
+ */
+void esp_br_web_epskc_set_active_tap(const char *tap);
+
+/**
+ * @brief Get the currently known active ePSKc TAP, if any. Backed by an atomic,
+ * independently thread-safe of the OpenThread lock, so it is safe to call
+ * regardless of whether that lock is held.
+ *
+ * @param[out] tap_out Buffer to receive the TAP string, at least ESP_BR_EPSKC_TAP_LEN bytes.
+ * @param[in] tap_out_len Size of tap_out.
+ * @return true if a TAP is currently known and was copied into tap_out, false otherwise.
+ */
+bool esp_br_web_epskc_get_active_tap(char *tap_out, size_t tap_out_len);
 
 #ifdef __cplusplus
 }

--- a/components/esp_ot_br_server/private_include/esp_br_web_api.h
+++ b/components/esp_ot_br_server/private_include/esp_br_web_api.h
@@ -37,6 +37,8 @@ void esp_br_web_api_init(void);
 #define ESP_OT_REST_API_NODE_BORDERAGENTID_PATH "/node/ba-id"
 #define ESP_OT_REST_API_NODE_DATASET_ACTIVE_PATH "/node/dataset/active"
 #define ESP_OT_REST_API_NODE_DATASET_PENDING_PATH "/node/dataset/pending"
+#define ESP_OT_REST_API_NODE_EPSKC_STATE_PATH "/node/ba-epskc/state"
+#define ESP_OT_REST_API_NODE_EPSKC_KEY_PATH "/node/ba-epskc/key"
 #define ESP_OT_REST_API_PROPERTIES_PATH "/get_properties"
 #define ESP_OT_REST_API_AVAILABLE_NETWORK_PATH "/available_network"
 #define ESP_OT_REST_API_NODE_INFORMATION_PATH "/node_information"
@@ -291,6 +293,46 @@ cJSON *handle_openthread_add_ipaddr_request(const cJSON *request);
  * @return A cJSON object with status, or NULL on failure.
  */
 cJSON *handle_openthread_delete_ipaddr_request(const cJSON *request);
+
+/**
+ * @brief Get whether the Border Agent ephemeral key (ePSKc) feature is enabled.
+ *
+ * @return The cJSON string "enabled" or "disabled".
+ */
+cJSON *handle_ot_resource_node_epskc_state_request(void);
+
+/**
+ * @brief Enable or disable the Border Agent ephemeral key (ePSKc) feature.
+ *
+ * @param[in] request  A cJSON string, either "enable" or "disable".
+ *
+ * @return
+ *      -   OT_ERROR_NONE           :   On success.
+ *      -   OT_ERROR_INVALID_ARGS   :   The @param request is invalid.
+ */
+otError handle_ot_resource_node_epskc_state_put_request(const cJSON *request);
+
+/**
+ * @brief Get the status of the Border Agent ephemeral key (ePSKc) session.
+ *
+ * @return The cJSON object with "state" and "port".
+ */
+cJSON *handle_ot_resource_node_epskc_key_get_request(void);
+
+/**
+ * @brief Generate and activate an ephemeral key (ePSKc).
+ *
+ * @param[in]  request  An optional cJSON object with "lifetime" (milliseconds) and "port". May be NULL.
+ * @param[out] log      A cJSON object used to record the "ErrorCode" (200/400/409/500) of the operation.
+ *
+ * @return The cJSON object with "tap" and "port" on success, otherwise NULL.
+ */
+cJSON *handle_ot_resource_node_epskc_key_post_request(const cJSON *request, cJSON *log);
+
+/**
+ * @brief Deactivate the currently active ephemeral key (ePSKc), if any.
+ */
+void handle_ot_resource_node_epskc_key_delete_request(void);
 
 #ifdef __cplusplus
 }

--- a/components/esp_ot_br_server/src/esp_br_web.c
+++ b/components/esp_ot_br_server/src/esp_br_web.c
@@ -4,9 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <inttypes.h>
 #include <limits.h>
+#include <stdatomic.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "sdkconfig.h"
@@ -101,6 +104,11 @@ static esp_err_t esp_otbr_network_node_baid_get_handler(httpd_req_t *req);
 static esp_err_t esp_otbr_network_node_dataset_active_handler(httpd_req_t *req);
 static esp_err_t esp_otbr_network_node_dataset_pending_handler(httpd_req_t *req);
 static esp_err_t esp_otbr_network_node_dataset_handler(httpd_req_t *req, const char *dataset_type);
+static esp_err_t esp_otbr_network_node_epskc_state_get_handler(httpd_req_t *req);
+static esp_err_t esp_otbr_network_node_epskc_state_put_handler(httpd_req_t *req);
+static esp_err_t esp_otbr_network_node_epskc_key_get_handler(httpd_req_t *req);
+static esp_err_t esp_otbr_network_node_epskc_key_post_handler(httpd_req_t *req);
+static esp_err_t esp_otbr_network_node_epskc_key_delete_handler(httpd_req_t *req);
 
 static httpd_uri_t s_resource_handlers[] = {
     {
@@ -204,6 +212,36 @@ static httpd_uri_t s_resource_handlers[] = {
         .method = HTTP_PUT,
         .handler = esp_otbr_network_node_dataset_pending_handler,
         .user_ctx = &s_server.data,
+    },
+    {
+        .uri = ESP_OT_REST_API_NODE_EPSKC_STATE_PATH,
+        .method = HTTP_GET,
+        .handler = esp_otbr_network_node_epskc_state_get_handler,
+        .user_ctx = NULL,
+    },
+    {
+        .uri = ESP_OT_REST_API_NODE_EPSKC_STATE_PATH,
+        .method = HTTP_PUT,
+        .handler = esp_otbr_network_node_epskc_state_put_handler,
+        .user_ctx = &s_server.data,
+    },
+    {
+        .uri = ESP_OT_REST_API_NODE_EPSKC_KEY_PATH,
+        .method = HTTP_GET,
+        .handler = esp_otbr_network_node_epskc_key_get_handler,
+        .user_ctx = NULL,
+    },
+    {
+        .uri = ESP_OT_REST_API_NODE_EPSKC_KEY_PATH,
+        .method = HTTP_POST,
+        .handler = esp_otbr_network_node_epskc_key_post_handler,
+        .user_ctx = &s_server.data,
+    },
+    {
+        .uri = ESP_OT_REST_API_NODE_EPSKC_KEY_PATH,
+        .method = HTTP_DELETE,
+        .handler = esp_otbr_network_node_epskc_key_delete_handler,
+        .user_ctx = NULL,
     },
 };
 
@@ -685,6 +723,97 @@ exit:
     cJSON_Delete(request);
     cJSON_Delete(response);
     cJSON_Delete(log);
+    return ret;
+}
+
+static esp_err_t esp_otbr_network_node_epskc_state_get_handler(httpd_req_t *req)
+{
+    esp_err_t ret = ESP_OK;
+    cJSON *response = handle_ot_resource_node_epskc_state_request();
+    ESP_GOTO_ON_ERROR(httpd_send_packet(req, response), exit, WEB_TAG, "Failed to response %s", req->uri);
+exit:
+    cJSON_Delete(response);
+    return ret;
+}
+
+static esp_err_t esp_otbr_network_node_epskc_state_put_handler(httpd_req_t *req)
+{
+    esp_err_t ret = ESP_OK;
+    otError err = OT_ERROR_NONE;
+    cJSON *state = httpd_request_convert2_json(req, cJSON_Object);
+    if (cJSON_IsString(state)) {
+        err = handle_ot_resource_node_epskc_state_put_request(state);
+    } else {
+        ESP_LOGE(WEB_TAG, "Invalid args");
+        err = OT_ERROR_INVALID_ARGS;
+    }
+
+    char http_return_status[64];
+    if (convert_ot_err_to_response_code(err, http_return_status) != ESP_OK) {
+        strcpy(http_return_status, HTTPD_500);
+    }
+    httpd_resp_set_status(req, http_return_status);
+    ESP_GOTO_ON_ERROR(httpd_resp_send(req, NULL, 0), exit, WEB_TAG, "Failed to response %s", req->uri);
+exit:
+    cJSON_Delete(state);
+    return ret;
+}
+
+static esp_err_t esp_otbr_network_node_epskc_key_get_handler(httpd_req_t *req)
+{
+    esp_err_t ret = ESP_OK;
+    cJSON *response = handle_ot_resource_node_epskc_key_get_request();
+    ESP_GOTO_ON_ERROR(httpd_send_packet(req, response), exit, WEB_TAG, "Failed to response %s", req->uri);
+exit:
+    cJSON_Delete(response);
+    return ret;
+}
+
+static esp_err_t esp_otbr_network_node_epskc_key_post_handler(httpd_req_t *req)
+{
+    esp_err_t ret = ESP_OK;
+    cJSON *request = NULL;
+    cJSON *response = NULL;
+    cJSON *log = cJSON_CreateObject();
+    uint16_t errcode = 0;
+
+    if (req->content_len > 0) {
+        request = httpd_request_convert2_json(req, cJSON_Object);
+        if (!cJSON_IsObject(request)) {
+            errcode = 400;
+        }
+    }
+
+    if (errcode == 0) {
+        response = handle_ot_resource_node_epskc_key_post_request(request, log);
+        cJSON *value = cJSON_GetObjectItemCaseSensitive(log, "ErrorCode");
+        if (cJSON_IsNumber(value)) {
+            errcode = (uint16_t)cJSON_GetNumberValue(value);
+        }
+    }
+
+    char http_return_status[64];
+    ot_br_web_response_code_get(errcode, http_return_status);
+    httpd_resp_set_status(req, http_return_status);
+    if (response) {
+        ESP_GOTO_ON_ERROR(httpd_send_packet(req, response), exit, WEB_TAG, "Failed to response %s", req->uri);
+    } else {
+        ESP_GOTO_ON_ERROR(httpd_resp_send(req, NULL, 0), exit, WEB_TAG, "Failed to response %s", req->uri);
+    }
+exit:
+    cJSON_Delete(request);
+    cJSON_Delete(response);
+    cJSON_Delete(log);
+    return ret;
+}
+
+static esp_err_t esp_otbr_network_node_epskc_key_delete_handler(httpd_req_t *req)
+{
+    esp_err_t ret = ESP_OK;
+    handle_ot_resource_node_epskc_key_delete_request();
+    httpd_resp_set_status(req, HTTPD_200);
+    ESP_GOTO_ON_ERROR(httpd_resp_send(req, NULL, 0), exit, WEB_TAG, "Failed to response %s", req->uri);
+exit:
     return ret;
 }
 
@@ -1406,4 +1535,32 @@ void esp_br_web_start(char *base_path)
 {
     ESP_ERROR_CHECK(esp_event_handler_register(IP_EVENT, IP_EVENT_STA_GOT_IP, &handler_got_ip_event, base_path));
     ESP_ERROR_CHECK(esp_event_handler_register(IP_EVENT, IP_EVENT_ETH_GOT_IP, &handler_got_ip_event, base_path));
+}
+
+/* 9-digit TAPs only span [0, 999999999], so this is safe to use as an invalid/sentinel value. */
+#define EPSKC_TAP_INVALID 1000000000
+
+static _Atomic uint32_t s_active_epskc_tap = EPSKC_TAP_INVALID;
+
+void esp_br_web_epskc_set_active_tap(const char *tap)
+{
+    uint32_t value = EPSKC_TAP_INVALID;
+
+    if (tap != NULL && strlen(tap) == 9) {
+        value = (uint32_t)strtoul(tap, NULL, 10);
+    }
+
+    atomic_store(&s_active_epskc_tap, value);
+}
+
+bool esp_br_web_epskc_get_active_tap(char *tap_out, size_t tap_out_len)
+{
+    uint32_t value = atomic_load(&s_active_epskc_tap);
+
+    if (value == EPSKC_TAP_INVALID || tap_out == NULL || tap_out_len < 10) {
+        return false;
+    }
+
+    snprintf(tap_out, tap_out_len, "%09" PRIu32, value);
+    return true;
 }

--- a/components/esp_ot_br_server/src/esp_br_web_api.c
+++ b/components/esp_ot_br_server/src/esp_br_web_api.c
@@ -7,6 +7,7 @@
 #include "sdkconfig.h"
 
 #include "cJSON.h"
+#include "esp_br_web.h"
 #include "esp_br_web_api.h"
 #include "esp_br_web_base.h"
 #include "esp_check.h"
@@ -27,6 +28,7 @@
 #include "freertos/portmacro.h"
 #include "freertos/semphr.h"
 #include "openthread/border_agent.h"
+#include "openthread/border_agent_ephemeral_key.h"
 #include "openthread/border_router.h"
 #include "openthread/commissioner.h"
 #include "openthread/dataset.h"
@@ -1445,4 +1447,171 @@ cJSON *handle_openthread_delete_ipaddr_request(const cJSON *request)
         ESP_LOGE(API_TAG, "Failed to remove IPv6 address: %s (err=%d)", addr_json->valuestring, err);
     }
     return result;
+}
+
+/*----------------------------------------------------------------------
+            Border Agent ephemeral key (ePSKc)
+----------------------------------------------------------------------*/
+#define EPSKC_TAP_STRING_SIZE (OT_BORDER_AGENT_EPHEMERAL_KEY_TAP_STRING_LENGTH + 1) /* 9 TAP chars + '\0' */
+
+static const char *epskc_state_to_string(otBorderAgentEphemeralKeyState state)
+{
+    switch (state) {
+    case OT_BORDER_AGENT_STATE_DISABLED:
+        return "disabled";
+    case OT_BORDER_AGENT_STATE_STOPPED:
+        return "stopped";
+    case OT_BORDER_AGENT_STATE_STARTED:
+        return "started";
+    case OT_BORDER_AGENT_STATE_CONNECTED:
+        return "connected";
+    case OT_BORDER_AGENT_STATE_ACCEPTED:
+        return "accepted";
+    default:
+        return "unknown";
+    }
+}
+
+/**
+ * @brief Generate a random 9-digit Thread Administration Passcode (TAP) via OpenThread's
+ *        own Verhoeff-checksummed TAP generator.
+ */
+static bool generate_epskc_tap(char *tap_buf)
+{
+    otBorderAgentEphemeralKeyTap tap;
+
+    if (otBorderAgentEphemeralKeyGenerateTap(&tap) != OT_ERROR_NONE) {
+        return false;
+    }
+    memcpy(tap_buf, tap.mTap, sizeof(tap.mTap));
+
+    return true;
+}
+
+cJSON *handle_ot_resource_node_epskc_state_request(void)
+{
+    otBorderAgentEphemeralKeyState state;
+
+    esp_openthread_lock_acquire(portMAX_DELAY);
+    state = otBorderAgentEphemeralKeyGetState(esp_openthread_get_instance());
+    esp_openthread_lock_release();
+
+    return cJSON_CreateString(state == OT_BORDER_AGENT_STATE_DISABLED ? "disabled" : "enabled");
+}
+
+otError handle_ot_resource_node_epskc_state_put_request(const cJSON *request)
+{
+    const char *state = cJSON_IsString(request) ? cJSON_GetStringValue(request) : NULL;
+
+    ESP_RETURN_ON_FALSE(state, OT_ERROR_INVALID_ARGS, API_TAG, "Invalid ePSKc state");
+    ESP_RETURN_ON_FALSE(strcmp(state, "enable") == 0 || strcmp(state, "disable") == 0, OT_ERROR_INVALID_ARGS, API_TAG,
+                        "Invalid ePSKc state[%s]", state);
+
+    esp_openthread_lock_acquire(portMAX_DELAY);
+    otBorderAgentEphemeralKeySetEnabled(esp_openthread_get_instance(), strcmp(state, "enable") == 0);
+    esp_openthread_lock_release();
+
+    return OT_ERROR_NONE;
+}
+
+cJSON *handle_ot_resource_node_epskc_key_get_request(void)
+{
+    cJSON *root = cJSON_CreateObject();
+    otInstance *ins;
+    otBorderAgentEphemeralKeyState state;
+    uint16_t port;
+
+    esp_openthread_lock_acquire(portMAX_DELAY);
+    ins = esp_openthread_get_instance();
+    state = otBorderAgentEphemeralKeyGetState(ins);
+    port = otBorderAgentEphemeralKeyGetUdpPort(ins);
+    esp_openthread_lock_release();
+
+    cJSON_AddStringToObject(root, "state", epskc_state_to_string(state));
+    cJSON_AddNumberToObject(root, "port", port);
+    return root;
+}
+
+cJSON *handle_ot_resource_node_epskc_key_post_request(const cJSON *request, cJSON *log)
+{
+    cJSON *response = NULL;
+    uint16_t errcode = 200;
+    otError err = OT_ERROR_NONE;
+    uint32_t lifetime = 0;
+    uint16_t port = 0;
+    char tap[EPSKC_TAP_STRING_SIZE] = "";
+    otInstance *ins;
+
+    if (request) {
+        cJSON *value = cJSON_GetObjectItemCaseSensitive(request, "lifetime");
+        if (value) {
+            if (!cJSON_IsNumber(value) || value->valuedouble < 0.0 || value->valuedouble > UINT32_MAX) {
+                errcode = 400;
+                goto exit;
+            }
+            lifetime = (uint32_t)value->valuedouble;
+        }
+
+        value = cJSON_GetObjectItemCaseSensitive(request, "port");
+        if (value) {
+            if (!cJSON_IsNumber(value) || value->valuedouble < 0.0 || value->valuedouble > UINT16_MAX) {
+                errcode = 400;
+                goto exit;
+            }
+            port = (uint16_t)value->valuedouble;
+        }
+    }
+
+    if (lifetime > OT_BORDER_AGENT_MAX_EPHEMERAL_KEY_TIMEOUT) {
+        errcode = 400;
+        goto exit;
+    }
+
+    if (!generate_epskc_tap(tap)) {
+        ESP_LOGE(API_TAG, "Failed to generate ePSKc TAP");
+        errcode = 500;
+        goto exit;
+    }
+
+    esp_openthread_lock_acquire(portMAX_DELAY);
+    ins = esp_openthread_get_instance();
+    err = otBorderAgentEphemeralKeyStart(ins, tap, lifetime, port);
+    if (err == OT_ERROR_NONE) {
+        port = otBorderAgentEphemeralKeyGetUdpPort(ins);
+        esp_br_web_epskc_set_active_tap(tap);
+    }
+    esp_openthread_lock_release();
+
+    switch (err) {
+    case OT_ERROR_NONE:
+        errcode = 200;
+        break;
+    case OT_ERROR_INVALID_STATE:
+        errcode = 409;
+        break;
+    case OT_ERROR_INVALID_ARGS:
+        errcode = 400;
+        break;
+    default:
+        errcode = 500;
+        break;
+    }
+
+    if (err == OT_ERROR_NONE) {
+        response = cJSON_CreateObject();
+        cJSON_AddStringToObject(response, "tap", tap);
+        cJSON_AddNumberToObject(response, "port", port);
+    }
+
+exit:
+    cJSON_AddItemToObject(log, "ErrorCode", cJSON_CreateNumber(errcode));
+    return response;
+}
+
+void handle_ot_resource_node_epskc_key_delete_request(void)
+{
+    esp_openthread_lock_acquire(portMAX_DELAY);
+    otBorderAgentEphemeralKeyStop(esp_openthread_get_instance());
+    esp_br_web_epskc_set_active_tap(NULL);
+    esp_openthread_lock_release();
 }

--- a/components/esp_ot_br_server/src/openapi.yaml
+++ b/components/esp_ot_br_server/src/openapi.yaml
@@ -291,6 +291,102 @@ paths:
           description: Successfully created the pending operational dataset.
         "400":
           description: Invalid request body.
+  /node/ba-epskc/state:
+    get:
+      tags:
+        - node
+      summary: Get whether the Border Agent ephemeral key (ePSKc) feature is enabled.
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: string
+                description: Whether the ephemeral key feature is enabled.
+                enum: ["enabled", "disabled"]
+                example: "enabled"
+    put:
+      tags:
+        - node
+      summary: Enable or disable the Border Agent ephemeral key (ePSKc) feature.
+      description: |-
+        The feature must be enabled before an ephemeral key can be activated
+        with a POST request to `/node/ba-epskc/key`.
+      responses:
+        "200":
+          description: Successful operation.
+        "400":
+          description: Invalid request body.
+      requestBody:
+        description: New ephemeral key feature state.
+        content:
+          application/json:
+            schema:
+              type: string
+              description: Can be "enable" or "disable".
+              example: "enable"
+  /node/ba-epskc/key:
+    get:
+      tags:
+        - node
+      summary: Get the status of the Border Agent ephemeral key (ePSKc) session.
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EpskcStatus"
+    post:
+      tags:
+        - node
+      summary: Generate and activate an ephemeral key (ePSKc).
+      description: |-
+        Generates a new 9-digit Thread Administration Passcode (TAP) and
+        starts listening for an external commissioner candidate to connect
+        using it. The ephemeral key feature must first be enabled with a PUT
+        request to `/node/ba-epskc/state`.
+      requestBody:
+        description: Optional activation parameters. An empty body uses the device defaults.
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                lifetime:
+                  type: integer
+                  description: |-
+                    The key lifetime in milliseconds. Defaults to 2 minutes
+                    when omitted or zero. Capped at 10 minutes.
+                  example: 120000
+                port:
+                  type: integer
+                  description: The UDP port to use. Defaults to an ephemeral port when omitted.
+                  example: 49152
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EpskcActivateResult"
+        "400":
+          description: Invalid request body.
+        "409":
+          description: Ephemeral key feature disabled, or a key is already active.
+        "500":
+          description: Failed to start the ephemeral key session.
+    delete:
+      tags:
+        - node
+      summary: Deactivate the currently active ephemeral key (ePSKc), if any.
+      description: |-
+        Stops the ephemeral key use and disconnects any commissioner session
+        using it. Has no effect if there is no ephemeral key in use.
+      responses:
+        "200":
+          description: Successful operation.
 components:
   schemas:
     LeaderData:
@@ -462,3 +558,26 @@ components:
       type: string
       description: Operational dataset as hex-encoded TLVs.
       example: 0E080000000000010000000300000F35060004001FFFE0020811111111222222220708FDAD70BFE5AA15DD051000112233445566778899AABBCCDDEEFF030E4F70656E54687265616444656D6F010212340410445F2B5CA6F2A93A55CE570A70EFEECB0C0402A0F7F8
+    EpskcStatus:
+      type: object
+      properties:
+        state:
+          type: string
+          description: The Border Agent ephemeral key session state.
+          enum: ["disabled", "stopped", "started", "connected", "accepted"]
+          example: "started"
+        port:
+          type: integer
+          description: The UDP port used by the ephemeral key session, if active.
+          example: 49152
+    EpskcActivateResult:
+      type: object
+      properties:
+        tap:
+          type: string
+          description: The generated 9-digit Thread Administration Passcode (TAP).
+          example: "123456789"
+        port:
+          type: integer
+          description: The UDP port the border agent is listening on for the ePSKc session.
+          example: 49152

--- a/examples/common/thread_border_router_m5stack/src/br_m5stack_epskc_page.c
+++ b/examples/common/thread_border_router_m5stack/src/br_m5stack_epskc_page.c
@@ -8,6 +8,7 @@
 #include "br_m5stack_epskc_page.h"
 #include "br_m5stack_common.h"
 #include "br_m5stack_layout.h"
+#include "esp_br_web.h"
 
 #include <stdatomic.h>
 #include <string.h>
@@ -49,6 +50,12 @@ static void delete_epskc_display_page(void *user_data)
 static void br_m5stack_meshcop_e_remove_handler(void *args, esp_event_base_t base, int32_t event_id, void *data)
 {
     lv_obj_t *page = NULL;
+
+    // The ePSKc session has ended, regardless of who stopped it (this screen's
+    // exit button, the REST API, or a natural timeout) - forget the TAP so it's
+    // no longer offered up as "currently active" to any UI.
+    esp_br_web_epskc_set_active_tap(NULL);
+
     page = atomic_exchange(&s_epskc_display_page, page);
     if (page) {
         lv_async_call(delete_epskc_display_page, (void *)page);
@@ -151,7 +158,9 @@ static lv_obj_t *create_qrcode_image(lv_obj_t *parent, const char *text, int sca
     return img;
 }
 
-static void create_ephemeral_key_page(char *key_txt)
+// Builds the QR code + key label + exit button page for an already-active TAP.
+// Does not itself start (or assume ownership of) the ephemeral key session.
+static void display_ephemeral_key_page(const char *key_txt)
 {
     esp_err_t ret = ESP_OK;
     br_m5stack_err_msg_t err_msg = "";
@@ -159,16 +168,8 @@ static void create_ephemeral_key_page(char *key_txt)
     lv_obj_t *label = NULL;
     lv_obj_t *qrcode_img = NULL;
     lv_obj_t *exit_btn = NULL;
-    otError err = OT_ERROR_NONE;
     char txt[13] = "";
 
-    esp_openthread_lock_acquire(portMAX_DELAY);
-    err = otBorderAgentEphemeralKeyStart(esp_openthread_get_instance(), key_txt,
-                                         CONFIG_OPENTHREAD_EPHEMERALKEY_LIFE_TIME * 1000,
-                                         CONFIG_OPENTHREAD_EPHEMERALKEY_PORT);
-    esp_openthread_lock_release();
-
-    BR_M5STACK_GOTO_ON_FALSE(err == OT_ERROR_NONE, exit, "Fail to apply ephemeral key");
     page = br_m5stack_create_blank_page(s_epskc_page);
     ESP_GOTO_ON_FALSE(page, ESP_FAIL, exit, BR_M5STACK_TAG, "Failed to create the page to display Ephemeral Key");
     atomic_store(&s_epskc_display_page, (lv_obj_t *)page);
@@ -193,6 +194,30 @@ exit:
     } else {
         BR_M5STACK_DELETE_OBJ_IF_EXIST(page);
     }
+}
+
+static void create_ephemeral_key_page(char *key_txt)
+{
+    br_m5stack_err_msg_t err_msg = "";
+    otError err = OT_ERROR_NONE;
+
+    esp_openthread_lock_acquire(portMAX_DELAY);
+    err = otBorderAgentEphemeralKeyStart(esp_openthread_get_instance(), key_txt,
+                                         CONFIG_OPENTHREAD_EPHEMERALKEY_LIFE_TIME * 1000,
+                                         CONFIG_OPENTHREAD_EPHEMERALKEY_PORT);
+    if (err == OT_ERROR_NONE) {
+        // Record the TAP so the REST API (or a later screen visit) can report
+        // the same key this screen just activated.
+        esp_br_web_epskc_set_active_tap(key_txt);
+    }
+    esp_openthread_lock_release();
+
+    BR_M5STACK_GOTO_ON_FALSE(err == OT_ERROR_NONE, exit, "Fail to apply ephemeral key");
+    display_ephemeral_key_page(key_txt);
+    return;
+
+exit:
+    BR_M5STACK_CREATE_WARNING_IF_EXIST(1000);
 }
 
 static bool generate_ephemeral_key(char *key_buf, bool random)
@@ -226,7 +251,10 @@ static void br_m5stack_epskc_page_display(lv_event_t *e)
     esp_ot_wifi_state_t wifi_state = OT_WIFI_DISCONNECTED;
     otDeviceRole thread_role = OT_DEVICE_ROLE_DISABLED;
     otBorderRoutingState br_state = OT_BORDER_ROUTING_STATE_UNINITIALIZED;
+    otBorderAgentEphemeralKeyState epskc_state = OT_BORDER_AGENT_STATE_DISABLED;
+    bool already_active = false;
     char random_digits[10];
+    char active_tap[ESP_BR_EPSKC_TAP_LEN] = "";
 
     esp_openthread_lock_acquire(portMAX_DELAY);
     instance = esp_openthread_get_instance();
@@ -239,6 +267,16 @@ static void br_m5stack_epskc_page_display(lv_event_t *e)
                                  : "Thread is not connected\nPlease check the state");
     br_state = otBorderRoutingGetState(esp_openthread_get_instance());
     BR_M5STACK_GOTO_ON_FALSE(br_state == OT_BORDER_ROUTING_STATE_RUNNING, exit, "Border router is not running");
+
+    // An ephemeral key session may already be running - e.g. started through
+    // the REST API. Reuse (and display) it instead of trying to start a
+    // second, conflicting one.
+    epskc_state = otBorderAgentEphemeralKeyGetState(instance);
+    already_active = (epskc_state != OT_BORDER_AGENT_STATE_DISABLED && epskc_state != OT_BORDER_AGENT_STATE_STOPPED);
+    if (already_active) {
+        BR_M5STACK_GOTO_ON_FALSE(esp_br_web_epskc_get_active_tap(active_tap, sizeof(active_tap)), exit,
+                                 "A key is already active but was\nstarted elsewhere; stop it first");
+    }
     error = ESP_OK;
 
 exit:
@@ -246,6 +284,11 @@ exit:
     if (error == ESP_OK) {
         // Display the page first
         br_m5stack_display_page(s_epskc_page);
+        if (already_active) {
+            // Show the already-active key instead of starting a new one.
+            display_ephemeral_key_page(active_tap);
+            return;
+        }
         // Generate random key and display it on the page
         BR_M5STACK_GOTO_ON_FALSE(generate_ephemeral_key(random_digits, true), exit2,
                                  "Failed to generate ephemeral key");


### PR DESCRIPTION
## Summary

- Adds `GET`/`PUT` `/node/ba-epskc/state` to query and toggle the Border Agent ephemeral key (ePSKc) feature.
- Adds `GET`/`POST`/`DELETE` `/node/ba-epskc/key` to query the ePSKc session status, generate and activate a new ephemeral key (Thread Administration Passcode), and deactivate the current one.
- Documents the new endpoints in `components/esp_ot_br_server/src/openapi.yaml`.

This exposes the Thread 1.4 Credentials Sharing (ePSKc) lifecycle over the REST API — previously only reachable from the M5Stack on-screen UI (`br_m5stack_epskc_page.c`), even though the core SDK already supports it (e.g. `esp_openthread_meshcop_mdns.c` links `otBorderAgentEphemeralKeyGetUdpPort`).

Endpoint naming and response shapes intentionally mirror [openthread/ot-br-posix#3480](https://github.com/openthread/ot-br-posix/pull/3480) so REST clients (e.g. `python-otbr-api`) can target either backend without special-casing, as discussed on the issue.

Closes #208

## Review feedback addressed

- Return `400` when `lifetime`/`port` in the ePSKc key `POST` body are present but not numbers, instead of silently ignoring them.
- Generate the ePSKc TAP via OpenThread's own `otBorderAgentEphemeralKeyGenerateTap()` instead of hand-rolling the digit + Verhoeff checksum generation.
- Store the shared active-TAP holder as an atomic `uint32_t` (`_Atomic uint32_t` + `EPSKC_TAP_INVALID` sentinel) instead of a plain `char[]`, so it's independently thread-safe and no longer needs the OpenThread lock to access.
- Removed the standalone test script (`test_epskc_api.py`); equivalent coverage will live in the internal test repo instead.

## Test plan

- [x] `idf.py build` — now verified: built ESP-IDF v5.5.5 (per #212) from source and compiled both `examples/basic_thread_border_router` and `examples/m5stack_thread_border_router` for `esp32s3` (plus the `ot_rcp` prerequisite for `esp32h2`). Both link and produce a flashable `esp_ot_br.bin` with no errors or warnings on any of the files this PR touches (`esp_br_web.c`, `esp_br_web_api.c`, `br_m5stack_epskc_page.c`).
- [x] Manual REST exercise against real hardware: enable/disable state, activate/query/deactivate key, error paths (409 double-activate, 400 bad body)
- [x] Existing `esp_ot_br_server` functionality unaffected (build + flash a basic_thread_border_router example)